### PR TITLE
Update Post2Post.php

### DIFF
--- a/lib/Post2Post.php
+++ b/lib/Post2Post.php
@@ -198,7 +198,7 @@ class Post2Post {
 
         $term = $this->functionsFacade->getTermBy('slug', $slug, $type);
 
-        if (!is_a($term, 'stdClass')) {
+        if (!($term instanceof stdClass)) {
             throw New Exception(
                 __('No term found with slug', 'p2p')
                 . ' "'


### PR DESCRIPTION
Replaced line 201 
if (!is_a($term, 'stdClass')) {
with 
if (!($term instanceof stdClass)) {
to work with current version of Wordpress.
